### PR TITLE
Replace regex JSON parsing with MessageParser

### DIFF
--- a/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/MessageParser.java
+++ b/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/MessageParser.java
@@ -1,0 +1,138 @@
+package edu.ntnu.bidata.smg.group8.common.protocol;
+
+import edu.ntnu.bidata.smg.group8.common.protocol.dto.HeartbeatMessage;
+import edu.ntnu.bidata.smg.group8.common.protocol.dto.RegisterMessage;
+import edu.ntnu.bidata.smg.group8.common.protocol.dto.SensorDataMessage;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Simple JSON message parser for the Smart Farm protocol.
+ * <p>
+ * This parser extracts fields from JSON messages and creates corresponding DTO objects.
+ * It uses a lightweight regex-based approach suitable for the protocol's simple JSON structure.
+ * <p>
+ * The parser handles both quoted string values and unquoted numeric/boolean values.
+ * Missing fields are represented as {@code null} in the resulting DTOs.
+ * <p>
+ * <b>Not a full JSON parser</b> - designed specifically for this protocol's message formats.
+ * Does not handle nested objects, arrays, or complex JSON structures.
+ *
+ * @see RegisterMessage
+ * @see SensorDataMessage
+ * @see HeartbeatMessage
+ */
+public final class MessageParser {
+
+  // Regex pattern to match both quoted strings and unquoted values (numbers, booleans)
+  private static final Pattern FIELD_PATTERN =
+            Pattern.compile("\"(\\w+)\"\\s*:\\s*(?:\"([^\"]*)\"|([^,}\\s]+))");
+
+  // JSON field names used in protocol messages
+  private static final String FIELD_TYPE = "type";
+  private static final String FIELD_ROLE = "role";
+  private static final String FIELD_NODE_ID = "nodeId";
+  private static final String FIELD_PROTOCOL_VERSION = "protocolVersion";
+  private static final String FIELD_MESSAGE = "message";
+  private static final String FIELD_SENSOR_KEY = "sensorKey";
+  private static final String FIELD_VALUE = "value";
+  private static final String FIELD_UNIT = "unit";
+  private static final String FIELD_TIMESTAMP = "timestamp";
+  private static final String FIELD_DIRECTION = "direction";
+
+  private MessageParser() {
+    // Util class - no instances allowed
+  }
+
+  /**
+   * Extracts the message type from a JSON message.
+   * <p>
+   * This is typically the first operation when processing an incoming message,
+   * as it determines which specific parser method to call.
+   * 
+   * @param json the JSON message string
+   * @return the message type (e.g., "REGISTER_NODE", "SENSOR_DATA"), or {@code null} if not found
+   */
+  public static String getType(String json) {
+    return getField(json, FIELD_TYPE);
+  }
+
+  /**
+   * Parses a registration message (REGISTER_NODE, REGISTER_CONTROL_PANEL or REGISTER_ACK).
+   * 
+   * @param json the JSON message string
+   * @return a RegisterMessage DTO containing the parsed fields
+   */
+  public static RegisterMessage parseRegister(String json) {
+    String type = getField(json, FIELD_TYPE);
+    String role = getField(json, FIELD_ROLE);
+    String nodeId = getField(json, FIELD_NODE_ID);
+    String protocolVersion = getField(json, FIELD_PROTOCOL_VERSION);
+    String message = getField(json, FIELD_MESSAGE);
+
+    return new RegisterMessage(type, role, nodeId, protocolVersion, message);
+  }
+
+  /**
+   * Parses a sensor data message (SENSOR_DATA).
+   * 
+   * @param json the JSON message string
+   * @return a SensorDataMessage DTO containing the parsed fields
+   */
+  public static SensorDataMessage parseSensorData(String json) {
+    String type = getField(json, FIELD_TYPE);
+    String nodeId = getField(json, FIELD_NODE_ID);
+    String sensorKey = getField(json, FIELD_SENSOR_KEY);
+    String value = getField(json, FIELD_VALUE);
+    String unit = getField(json, FIELD_UNIT);
+    String timestamp = getField(json, FIELD_TIMESTAMP);
+
+    return new SensorDataMessage(type, nodeId, sensorKey, value, unit, timestamp);
+  }
+
+  /**
+   * Parses a heartbeat message (HEARTBEAT).
+   * 
+   * @param json the JSON message string
+   * @return a HeartbeatMessage DTO containing the parsed fields
+   */
+  public static HeartbeatMessage parseHeartbeat(String json) {
+    String type = getField(json, FIELD_TYPE);
+    String direction = getField(json, FIELD_DIRECTION);
+    String protocolVersion = getField(json, FIELD_PROTOCOL_VERSION);
+    String nodeId = getField(json, FIELD_NODE_ID);
+
+    return new HeartbeatMessage(type, direction, protocolVersion, nodeId);
+  }
+
+  /**
+   * Extracts a field value from a JSON string.
+   * <p>
+   * Handles both:
+   * <ul>
+   *    <li>Quoted string values: {@code "key":"value"} -> returns {@code "value"}</li>
+   *    <li>Unquoted values: {@code "key":123} or {@code "key":true} -> returns {@code "123"} or {@code "true"}</li>
+   * </ul>
+   * 
+   * @param json the JSON message string
+   * @param key the field key to extract
+   * @return the field value as a string, or {@code null} if the field is not found
+   */
+  private static String getField(String json, String key) {
+    if (json == null || key == null) {
+      return null;
+    }
+
+    Matcher matcher = FIELD_PATTERN.matcher(json);
+    while (matcher.find()) {
+      String fieldName = matcher.group(1);
+      if (key.equals(fieldName)) {
+        // Group 2 = quoted value, Group 3 = unquoted value
+        String quotedValue = matcher.group(2);
+        String unquotedValue = matcher.group(3);
+        return quotedValue != null ? quotedValue : unquotedValue;
+      }
+    }
+    return null;
+  }
+}

--- a/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/dto/HeartbeatMessage.java
+++ b/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/dto/HeartbeatMessage.java
@@ -1,0 +1,85 @@
+package edu.ntnu.bidata.smg.group8.common.protocol.dto;
+
+/**
+ * Data Transfer Object for {@code HEARTBEAT} protocol messages.
+ * <p>
+ * Heartbeat messages are exchanged between clients and the server to verify
+ * connection health and prevent idle timeout disconnections.
+ * <p>
+ * The server sends heartbeats after detecting idle periods (default: 30 seconds without messages).
+ * Clients may also send heartbeats to indicate they are still active.
+ * <p>
+ * Example server-to-client heartbeat:
+ * {@code {"type":"HEARTBEAT","direction":"SERVER_TO_CLIENT","protocolVersion":"1.0"}}
+ * <p>
+ * Example client-to-server heartbeat:
+ * {@code {"type":"HEARTBEAT","direction":"CLIENT_TO_SERVER","nodeId":"dev-1"}}
+ */
+public final class HeartbeatMessage {
+  private final String type;
+  private final String direction; // "SERVER_TO_CLIENT" or "CLIENT_TO_SERVER"
+  private final String protocolVersion; // May be null
+  private final String nodeId; // May be null
+
+  /**
+   * Constructs a new HeartbeatMessage with the specified fields.
+   *
+   * @param type the message type (should be "HEARTBEAT")
+   * @param direction the direction of the heartbeat ("SERVER_TO_CLIENT" or "CLIENT_TO_SERVER")
+   * @param protocolVersion the protocol version string, may be {@code null}
+   * @param nodeId the unique identifier of the node sending the heartbeat, may be {@code null}
+   */
+  public HeartbeatMessage(String type, String direction, String protocolVersion, String nodeId) {
+    this.type = type;
+    this.direction = direction;
+    this.protocolVersion = protocolVersion;
+    this.nodeId = nodeId;
+  }
+
+  /**
+   * Returns the message type.
+   * 
+   * @return the message type (typically "HEARTBEAT")
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Returns the direction of the heartbeat.
+   * 
+   * @return "SERVER_TO_CLIENT" or "CLIENT_TO_SERVER"
+   */
+  public String getDirection() {
+    return direction;
+  }
+
+  /**
+   * Returns the protocol version.
+   * 
+   * @return the protocol version string (e.g., "1.0"), or {@code null} if not present
+   */
+  public String getProtocolVersion() {
+    return protocolVersion;
+  }
+
+  /**
+   * Returns the node identifier of the sender.
+   * 
+   * @return the node ID, or {@code null} if not present
+   */
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  @Override
+  public String toString() {
+    return "HeartbeatMessage{" +
+           "type='" + type + '\'' +
+           ", direction='" + direction + '\'' +
+           ", protocolVersion='" + protocolVersion + '\'' +
+           ", nodeId='" + nodeId + '\'' +
+           "}"; 
+  }
+}
+

--- a/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/dto/RegisterMessage.java
+++ b/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/dto/RegisterMessage.java
@@ -1,0 +1,101 @@
+package edu.ntnu.bidata.smg.group8.common.protocol.dto;
+
+/**
+ * Data Transfer Object for registration-related protocol messages.
+ * <p>
+ * Represents three message types:
+ * <ul>
+ *    <li>{@code REGISTER_NODE} - Sensor node registration request</li>
+ *    <li>{@code REGISTER_CONTROL_PANEL} - Control panel registration request</li>
+ *    <li>{@code REGISTER_ACK} - Server acknowledgment of successful registration</li>
+ * </ul>
+ * <p>
+ * Not all fields are present in every message type. Use {@code null} for absent fields.
+ * <p>
+ * Example REGISTER_NODE message:
+ * {@code {"type":"REGISTER_NODE","role":"SENSOR_NODE","nodeId":"dev-1"}}
+ * <p>
+ * Example REGISTER_ACK message:
+ * {@code {"type":"REGISTER_ACK","protocolVersion":"1.0","message":"Registration successful"}}
+ */
+public final class RegisterMessage {
+  private final String type;
+  private final String role;
+  private final String nodeId;
+  private final String protocolVersion;
+  private final String message;
+
+  /**
+   * Constructs a new RegisterMessage with the specified fields.
+   * 
+   * @param type the message type (e.g., "REGISTER_NODE", "REGISTER_ACK")
+   * @param role the role of the registering node ("SENSOR_NODE", "CONTROL_PANEL"),
+   *             may be {@code null} for REGISTER_ACK messages.
+   * @param nodeId the unique identifier for the node, may be {@code null}
+   * @param protocolVersion the protocol version string, may be {@code null} for registration requests
+   * @param message a readable message (typically used in REGISTER_ACK), may be {@code null}
+   */
+  public RegisterMessage(String type, String role, String nodeId, String protocolVersion, String message) {
+    this.type = type;
+    this.role = role;
+    this.nodeId = nodeId;
+    this.protocolVersion = protocolVersion;
+    this.message = message;
+  }
+
+  /**
+   * Returns the message type.
+   *
+   * @return the message type (example: "REGISTER_NODE")
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Returns the role of the node being registered.
+   * 
+   * @return the role ("SENSOR_NODE", "CONTROL_PANEL"), or {@code null} if not present.
+   */
+  public String getRole() {
+    return role;
+  }
+
+  /**
+   * Returns the unique node identifier.
+   * 
+   * @return the node ID, or {@code null} if not present
+   */
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  /**
+   * Returns the protocol version.
+   * 
+   * @return the protocol version string (e.g., "1.0"), or {@code null}, if not present
+   */
+  public String getProtocolVersion() {
+    return protocolVersion;
+  }
+
+  /**
+   * Returns the readable message.
+   * 
+   * @return the message text, or {@code null} if not present
+   */
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public String toString() {
+    return "RegisterMessage{" +
+           "type='" + type + '\'' +
+           ", role='" + role + '\'' +
+           ", nodeId='" + nodeId + '\'' +
+           ", protocolVersion='" + protocolVersion + '\'' +
+           ", message='" + message + '\'' +
+           "}";
+  }
+}

--- a/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/dto/SensorDataMessage.java
+++ b/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/dto/SensorDataMessage.java
@@ -1,0 +1,107 @@
+package edu.ntnu.bidata.smg.group8.common.protocol.dto;
+
+/**
+ * Data Transfer Object for {@code SENSOR_DATA} protocol messages.
+ * <p>
+ * Represents sensor readings transmitted from sensor nodes to the broker,
+ * which are then forwarded to all connected control panels.
+ * <p>
+ * Sensor data messages are typically sent periodically,
+ * or when significant value changes are detected.
+ * <p>
+ * Example message:
+ * {@code {"type":"SENSOR_DATA","nodeId":"dev-1","sensorKey":"temp-1","value":"22.5","unit":"°C","timestamp":"2025-11-01T10:30:00Z"}}
+ */
+public final class SensorDataMessage {
+  private final String type;
+  private final String nodeId;
+  private final String sensorKey; // Example: "temp-1", "humidity-2"
+  private final String value; // sensor reading value
+  private final String unit; // unit of measurement (may be null)
+  private final String timestamp; // Timestamp (may be null)
+  
+  /**
+   * Constructs a new SensorDataMessage with the specified fields.
+   * 
+   * @param type the message type (should be "SENSOR_DATA")
+   * @param nodeId the unique identifier of the sensor node
+   * @param sensorKey the unique key identifying the specific sensor ("temp-1", "humidity-2")
+   * @param value the sensor reading value as a string
+   * @param unit the unit of measurement (e.g., "°C", "%"), may be {@code null}
+   * @param timestamp the ISO 8601 timestamp of the reading, may be {@code null}
+   */
+  public SensorDataMessage (String type, String nodeId, String sensorKey, String value, String unit, String timestamp) {
+    this.type = type;
+    this.nodeId = nodeId;
+    this.sensorKey = sensorKey;
+    this.value = value;
+    this.unit = unit;
+    this.timestamp = timestamp;
+  }
+
+  /**
+   * Returns the message type.
+   *
+   * @return the message type (typically "SENSOR_DATA")
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Returns the unique identifier of the sensor node.
+   * 
+   * @return the node ID
+   */
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  /**
+   * Returns the unique key identifying the specific sensor.
+   * 
+   * @return the sensor key (e.g., "temp-1", "humidity-2")
+   */
+  public String getSensorKey() {
+    return sensorKey;
+  }
+
+  /**
+   * Returns the sensor reading value.
+   * 
+   * @return the sensor value as a string
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Returns the unit of measurement.
+   * 
+   * @return the unit (e.g., "°C", "%"), or {@code null} if not provided
+   */
+  public String getUnit() {
+    return unit;
+  }
+
+  /**
+   * Returns the timestamp of the sensor reading.
+   * 
+   * @return the ISO 8601 timestamp string, or {@code null} if not provided
+   */
+  public String getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public String toString() {
+    return "SensorDataMessage{" +
+           "type='" + type + '\'' +
+           ", nodeId='" + nodeId + '\'' +
+           ", sensorKey='" + sensorKey + '\'' +
+           ", value='" + value + '\'' +
+           ", unit='" + unit + '\'' +
+           ", timestamp='" + timestamp + '\'' +
+           "}";
+  }
+}

--- a/common/src/test/java/edu/ntnu/bidata/smg/group8/common/protocol/MessageParserTest.java
+++ b/common/src/test/java/edu/ntnu/bidata/smg/group8/common/protocol/MessageParserTest.java
@@ -1,0 +1,218 @@
+package edu.ntnu.bidata.smg.group8.common.protocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import edu.ntnu.bidata.smg.group8.common.protocol.dto.HeartbeatMessage;
+import edu.ntnu.bidata.smg.group8.common.protocol.dto.RegisterMessage;
+import edu.ntnu.bidata.smg.group8.common.protocol.dto.SensorDataMessage;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for MessageParser
+ */
+class MessageParserTest {
+
+  // ========== getType() Tests ==========
+
+  @Test
+  void testGetType_RegisterNode() {
+    String json = "{\"type\":\"REGISTER_NODE\",\"role\":\"SENSOR_NODE\",\"nodeId\":\"dev-1\"}";
+    String type = MessageParser.getType(json);
+    assertEquals("REGISTER_NODE", type);
+  }
+
+  @Test
+  void testGetType_SensorData() {
+    String json = "{\"type\":\"SENSOR_DATA\",\"nodeId\":\"dev-1\",\"sensorKey\":\"temp-1\",\"value\":\"22.5\"}";
+    String type = MessageParser.getType(json);
+    assertEquals("SENSOR_DATA", type);
+  }
+
+  @Test
+  void testGetType_Heartbeat() {
+    String json = "{\"type\":\"HEARTBEAT\",\"direction\":\"CLIENT_TO_SERVER\"}";
+    String type = MessageParser.getType(json);
+    assertEquals("HEARTBEAT", type);
+  }
+
+  @Test
+  void testGetType_MissingType() {
+    String json = "{\"role\":\"SENSOR_NODE\",\"nodeId\":\"dev-1\"}";
+    String type = MessageParser.getType(json);
+    assertNull(type);
+  }
+
+  @Test
+  void testGetType_NullInput() {
+    String type = MessageParser.getType(null);
+    assertNull(type);
+  }
+
+  // ========== parseRegister() Tests ==========
+
+  @Test
+  void testParseRegister_RegisterNode() {
+    String json = "{\"type\":\"REGISTER_NODE\",\"role\":\"SENSOR_NODE\",\"nodeId\":\"dev-1\"}";
+    RegisterMessage msg = MessageParser.parseRegister(json);
+
+    assertNotNull(msg);
+    assertEquals("REGISTER_NODE", msg.getType());
+    assertEquals("SENSOR_NODE", msg.getRole());
+    assertEquals("dev-1", msg.getNodeId());
+    assertNull(msg.getProtocolVersion());
+    assertNull(msg.getMessage());
+  }
+
+  @Test
+  void testParseRegister_RegisterControlPanel() {
+    String json = "{\"type\":\"REGISTER_CONTROL_PANEL\",\"role\":\"CONTROL_PANEL\",\"nodeId\":\"ui-1\"}";
+    RegisterMessage msg = MessageParser.parseRegister(json);
+
+    assertNotNull(msg);
+    assertEquals("REGISTER_CONTROL_PANEL", msg.getType());
+    assertEquals("CONTROL_PANEL", msg.getRole());
+    assertEquals("ui-1", msg.getNodeId());
+    assertNull(msg.getProtocolVersion());
+    assertNull(msg.getMessage());
+  }
+
+  @Test
+  void testParseRegister_RegisterAck() {
+    String json = "{\"type\":\"REGISTER_ACK\",\"protocolVersion\":\"1.0\",\"message\":\"Registration successful\"}";
+    RegisterMessage msg = MessageParser.parseRegister(json);
+
+    assertNotNull(msg);
+    assertEquals("REGISTER_ACK", msg.getType());
+    assertEquals("1.0", msg.getProtocolVersion());
+    assertEquals("Registration successful", msg.getMessage());
+    assertNull(msg.getRole());
+    assertNull(msg.getNodeId());
+  }
+
+  @Test
+  void testParseRegister_AllFields() {
+    String json = "{\"type\":\"REGISTER_ACK\",\"role\":\"SENSOR_NODE\",\"nodeId\":\"dev-1\",\"protocolVersion\":\"1.0\",\"message\":\"OK\"}";
+    RegisterMessage msg = MessageParser.parseRegister(json);
+
+    assertNotNull(msg);
+    assertEquals("REGISTER_ACK", msg.getType());
+    assertEquals("SENSOR_NODE", msg.getRole());
+    assertEquals("dev-1", msg.getNodeId());
+    assertEquals("1.0", msg.getProtocolVersion());
+    assertEquals("OK", msg.getMessage());
+  }
+
+  // ========== parseSensorData() Tests ==========
+
+  @Test
+  void testParseSensorData_AllFields() {
+    String json = "{\"type\":\"SENSOR_DATA\",\"nodeId\":\"dev-1\",\"sensorKey\":\"temp-1\",\"value\":\"22.5\",\"unit\":\"°C\",\"timestamp\":\"2025-11-01T10:30:00Z\"}";
+    SensorDataMessage msg = MessageParser.parseSensorData(json);
+
+    assertNotNull(msg);
+    assertEquals("SENSOR_DATA", msg.getType());
+    assertEquals("dev-1", msg.getNodeId());
+    assertEquals("temp-1", msg.getSensorKey());
+    assertEquals("22.5", msg.getValue());
+    assertEquals("°C", msg.getUnit());
+    assertEquals("2025-11-01T10:30:00Z", msg.getTimestamp());
+  }
+
+  @Test
+  void testParseSensorData_MinimalFields() {
+    String json = "{\"type\":\"SENSOR_DATA\",\"nodeId\":\"dev-1\",\"sensorKey\":\"humidity-2\",\"value\":\"65\"}";
+    SensorDataMessage msg = MessageParser.parseSensorData(json);
+
+    assertNotNull(msg);
+    assertEquals("SENSOR_DATA", msg.getType());
+    assertEquals("dev-1", msg.getNodeId());
+    assertEquals("humidity-2", msg.getSensorKey());
+    assertEquals("65", msg.getValue());
+    assertNull(msg.getUnit());
+    assertNull(msg.getTimestamp());
+  }
+
+  @Test
+  void testParseSensorData_UnquotedNumericValue() {
+    String json = "{\"type\":\"SENSOR_DATA\",\"nodeId\":\"dev-1\",\"sensorKey\":\"temp-1\",\"value\":22.5}";
+    SensorDataMessage msg = MessageParser.parseSensorData(json);
+
+    assertNotNull(msg);
+    assertEquals("22.5", msg.getValue());  // Should handle unquoted numbers
+  }
+
+  // ========== parseHeartbeat() Tests ==========
+
+  @Test
+  void testParseHeartbeat_ServerToClient() {
+    String json = "{\"type\":\"HEARTBEAT\",\"direction\":\"SERVER_TO_CLIENT\",\"protocolVersion\":\"1.0\"}";
+    HeartbeatMessage msg = MessageParser.parseHeartbeat(json);
+
+    assertNotNull(msg);
+    assertEquals("HEARTBEAT", msg.getType());
+    assertEquals("SERVER_TO_CLIENT", msg.getDirection());
+    assertEquals("1.0", msg.getProtocolVersion());
+    assertNull(msg.getNodeId());
+  }
+
+  @Test
+  void testParseHeartbeat_ClientToServer() {
+    String json = "{\"type\":\"HEARTBEAT\",\"direction\":\"CLIENT_TO_SERVER\",\"nodeId\":\"dev-1\"}";
+    HeartbeatMessage msg = MessageParser.parseHeartbeat(json);
+
+    assertNotNull(msg);
+    assertEquals("HEARTBEAT", msg.getType());
+    assertEquals("CLIENT_TO_SERVER", msg.getDirection());
+    assertEquals("dev-1", msg.getNodeId());
+    assertNull(msg.getProtocolVersion());
+  }
+
+  @Test
+  void testParseHeartbeat_AllFields() {
+    String json = "{\"type\":\"HEARTBEAT\",\"direction\":\"CLIENT_TO_SERVER\",\"protocolVersion\":\"1.0\",\"nodeId\":\"dev-1\"}";
+    HeartbeatMessage msg = MessageParser.parseHeartbeat(json);
+
+    assertNotNull(msg);
+    assertEquals("HEARTBEAT", msg.getType());
+    assertEquals("CLIENT_TO_SERVER", msg.getDirection());
+    assertEquals("1.0", msg.getProtocolVersion());
+    assertEquals("dev-1", msg.getNodeId());
+  }
+
+  // ========== Edge Cases ==========
+
+  @Test
+  void testParseRegister_EmptyJson() {
+    String json = "{}";
+    RegisterMessage msg = MessageParser.parseRegister(json);
+
+    assertNotNull(msg);
+    assertNull(msg.getType());
+    assertNull(msg.getRole());
+    assertNull(msg.getNodeId());
+    assertNull(msg.getProtocolVersion());
+    assertNull(msg.getMessage());
+  }
+
+  @Test
+  void testParseRegister_ExtraWhitespace() {
+    String json = "{ \"type\" : \"REGISTER_NODE\" , \"role\" : \"SENSOR_NODE\" , \"nodeId\" : \"dev-1\" }";
+    RegisterMessage msg = MessageParser.parseRegister(json);
+
+    assertNotNull(msg);
+    assertEquals("REGISTER_NODE", msg.getType());
+    assertEquals("SENSOR_NODE", msg.getRole());
+    assertEquals("dev-1", msg.getNodeId());
+  }
+
+  @Test
+  void testParseSensorData_BooleanValue() {
+    String json = "{\"type\":\"SENSOR_DATA\",\"nodeId\":\"dev-1\",\"sensorKey\":\"active\",\"value\":true}";
+    SensorDataMessage msg = MessageParser.parseSensorData(json);
+
+    assertNotNull(msg);
+    assertEquals("true", msg.getValue());  // Should convert boolean to string
+  }
+}


### PR DESCRIPTION
Created DTOs for RegisterMessage, SensorDataMessage, and HeartbeatMessage. Implemented MessageParser in common module for type-safe parsing. Updated ClientHandler to use MessageParser instead of regex.

Resoves Issue #62