### PR TITLE
Implemented NODE_CONNECTED/NODE_DISCONNECTED event broadcasting

### DIFF
--- a/broker/src/test/java/edu/ntnu/bidata/smg/group8/broker/infra/network/TcpServerIntegrationTest.java
+++ b/broker/src/test/java/edu/ntnu/bidata/smg/group8/broker/infra/network/TcpServerIntegrationTest.java
@@ -81,6 +81,10 @@ class TcpServerIntegrationTest {
       String sensorAck = readJson(sensor);
       assertTrue(sensorAck.contains(Protocol.TYPE_REGISTER_ACK));
 
+      // Panel receives NODE_CONNECTED event after sensor registration
+      String nodeConnected = readJson(panel);
+      assertTrue(nodeConnected.contains(Protocol.TYPE_NODE_CONNECTED));
+
       // Send SENSOR_DATA from sensor
       String data = Jsons.sensorData("{\"value\":42}");
       writeJson(sensor, data);

--- a/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/Protocol.java
+++ b/common/src/main/java/edu/ntnu/bidata/smg/group8/common/protocol/Protocol.java
@@ -1,5 +1,9 @@
 package edu.ntnu.bidata.smg.group8.common.protocol;
 
+import java.awt.desktop.PrintFilesEvent;
+
+import javax.sound.sampled.SourceDataLine;
+
 /**
  * Protocol constants for the Smart Farm Messaging Protocol.
  */
@@ -20,6 +24,8 @@ public final class Protocol {
   public static final String TYPE_ACTUATOR_STATE = "ACTUATOR_STATE";
   public static final String TYPE_HEARTBEAT = "HEARTBEAT";
   public static final String TYPE_ERROR = "ERROR";
+  public static final String TYPE_NODE_CONNECTED = "NODE_CONNECTED";
+  public static final String TYPE_NODE_DISCONNECTED = "NODE_DISCONNECTED";
 
   // Roles
   public static final String ROLE_SENSOR_NODE = "SENSOR_NODE";


### PR DESCRIPTION
Added broadcastNodeEvent() helper to broadcast node lifecycle events. Control Panel now receive real-time updates when sensor nodes connect/disconnects. Updated integration test to verify event delivery.

Closes #61